### PR TITLE
Removing unused sum variable

### DIFF
--- a/mafExtractor/src/mafExtractorAPI.c
+++ b/mafExtractor/src/mafExtractorAPI.c
@@ -190,9 +190,9 @@ mafBlock_t *processBlockForSplice(mafBlock_t *b, uint64_t blockNumber, const cha
     maf_mafBlock_print(b);
     */
     bool *targetColumns = NULL;
-    uint64_t len = 0, sum = 0;
+    uint64_t len = 0;
     mafBlock_t *head = NULL, *mb = NULL;
-    sum = getTargetColumns(&targetColumns, &len, b, seq, start, stop);
+    getTargetColumns(&targetColumns, &len, b, seq, start, stop);
     // printTargetColumns(targetColumns, len);
     int64_t **offsets = createOffsets(maf_mafBlock_getNumberOfSequences(b));
     uint64_t l = 0, r = 0, ri = 0;


### PR DESCRIPTION
Discards the return value that the variable was holding, since it never gets read. Allows mafExtractor to build on GCC 4.9.0. Closes #6.
