### PR TITLE
Ensure return of `runCommand`  in lib/createVersionSources.py  is a string

### DIFF
--- a/lib/createVersionSources.py
+++ b/lib/createVersionSources.py
@@ -39,7 +39,7 @@ GIT = mtt.which('git')
 
 
 def runCommand(cmd):
-  p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+  p = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True)
   pout, perr = p.communicate()
   mtt.handleReturnCode(p.returncode, cmd)
   return pout


### PR DESCRIPTION
Using python 2.7.10 on linux most of the tools fail to compile with message 

```
Traceback (most recent call last):
  File "../lib/createVersionSources.py", line 93, in <module>
    main()
  File "../lib/createVersionSources.py", line 86, in main
    buildBranch = getBranch()
  File "../lib/createVersionSources.py", line 49, in getBranch
    branchList = runCommand([GIT, 'branch']).split('\n')
TypeError: a bytes-like object is required, not 'str'
Makefile:18: recipe for target 'src/buildVersion.c' failed
make[1]: *** [src/buildVersion.c] Error 1
```
This appears to stem from the  subprocess module  (now ?) captures stdout. By default it's a `bytes` object which can't be `split()` by a string. 

This commit sets `universal_newlines=True` when calling Popen, which ensures a string is returned. (This argument was present in earlier versions of Python 2.7, so this should have no effect when those versions are used).