### PR TITLE
Add externs to global vars to fix linking on gcc 11.2

### DIFF
--- a/inc/common.h
+++ b/inc/common.h
@@ -27,11 +27,11 @@
 #include <stdio.h>
 #include <stdint.h>
 
-int g_verbose_flag;
-int g_debug_flag;
-const int kMaxStringLength;
-const int kMaxMessageLength;
-const int kMaxSeqName;
+extern int g_verbose_flag;
+extern int g_debug_flag;
+extern const int kMaxStringLength;
+extern const int kMaxMessageLength;
+extern const int kMaxSeqName;
 
 void de_verbose(char const *fmt, ...);
 void de_debug(char const *fmt, ...);

--- a/lib/sharedMaf.c
+++ b/lib/sharedMaf.c
@@ -1008,7 +1008,7 @@ void maf_mafBlock_print(mafBlock_t *m) {
   mafLine_t* ml = maf_mafBlock_getHeadLine(m);
   char *line = NULL;
   uint64_t maxName = 1, maxStart = 1, maxLen = 1, maxSource = 1;
-  char fmtName[10] = "\0", fmtStart[32] = "\0", fmtLen[32] = "\0", fmtSource[32] = "\0", fmtLine[256] = "\0";
+  char fmtName[32] = "\0", fmtStart[32] = "\0", fmtLen[32] = "\0", fmtSource[32] = "\0", fmtLine[256] = "\0";
   while (ml != NULL) {
     line = maf_mafLine_getLine(ml);
     if (line == NULL) {

--- a/mafComparator/src/comparatorAPI.c
+++ b/mafComparator/src/comparatorAPI.c
@@ -33,6 +33,7 @@
 #include "comparatorRandom.h"
 
 const unsigned kChooseTwoCacheLength = 101;
+bool g_isVerboseFailures = false;
 
 void aPair_fillOut(APair *aPair, char *seq1, char *seq2, uint64_t pos1, uint64_t pos2) {
     int i = strcmp(seq1, seq2);

--- a/mafComparator/src/comparatorAPI.h
+++ b/mafComparator/src/comparatorAPI.h
@@ -102,7 +102,7 @@ typedef struct _wiggleContainer {
     uint64_t *absentAtoB;
     uint64_t *absentBtoA;
 } WiggleContainer;
-bool g_isVerboseFailures;
+extern bool g_isVerboseFailures;
 
 Options* options_construct(void);
 void options_destruct(Options* o);

--- a/mafComparator/src/mafComparator.c
+++ b/mafComparator/src/mafComparator.c
@@ -43,7 +43,6 @@
 #include "buildVersion.h"
 
 const char *g_version = "version 0.9 May 2013";
-bool g_isVerboseFailures = false;
 
 /*
  * The script takes two MAF files and for each ordered pair of sequences


### PR DESCRIPTION
maftools won't build on ubuntu 22 (even with werror hacked off) because
```
cc -std=c99 -Wno-unused-but-set-variable -O3 -Wall  --pedantic -funroll-loops -DNDEBUG -Wshadow -Wpointer-arith -Wstrict-prototypes -Wmissing-prototypes -I ../../sonLib/lib -I ../inc -I ../external  -O3 src/mafPositionFinder.c ../lib/common.o ../lib/sharedMaf.o ../external/CuTest.a src/buildVersion.o -o ../bin/mafPositionFinder.tmp -lm
/usr/bin/ld: ../lib/common.o:(.bss+0x4): multiple definition of `g_verbose_flag'; /tmp/ccsWimg6.o:(.bss+0x4): first defined here
/usr/bin/ld: ../lib/common.o:(.bss+0x0): multiple definition of `g_debug_flag'; /tmp/ccsWimg6.o:(.bss+0x0): first defined here
/usr/bin/ld: ../lib/common.o:(.rodata+0xc): multiple definition of `kMaxSeqName'; /tmp/ccsWimg6.o:(.rodata+0x5c): first defined here
/usr/bin/ld: ../lib/common.o:(.rodata+0x10): multiple definition of `kMaxMessageLength'; /tmp/ccsWimg6.o:(.rodata+0x60): first defined here
/usr/bin/ld: ../lib/common.o:(.rodata+0x14): multiple definition of `kMaxStringLength'; /tmp/ccsWimg6.o:(.rodata+0x64): first defined here
/usr/bin/ld: ../lib/sharedMaf.o:(.rodata+0x5c4): multiple definition of `kMaxSeqName'; /tmp/ccsWimg6.o:(.rodata+0x5c): first defined here
/usr/bin/ld: ../lib/sharedMaf.o:(.rodata+0x5c8): multiple definition of `kMaxMessageLength'; /tmp/ccsWimg6.o:(.rodata+0x60): first defined here
/usr/bin/ld: ../lib/sharedMaf.o:(.rodata+0x5cc): multiple definition of `kMaxStringLength'; /tmp/ccsWimg6.o:(.rodata+0x64): first defined here
/usr/bin/ld: ../lib/sharedMaf.o:(.bss+0x0): multiple definition of `g_debug_flag'; /tmp/ccsWimg6.o:(.bss+0x0): first defined here
/usr/bin/ld: ../lib/sharedMaf.o:(.bss+0x4): multiple definition of `g_verbose_flag'; /tmp/ccsWimg6.o:(.bss+0x4): first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:24: ../bin/mafPositionFinder] Error 1
make[1]: Leaving directory '/mafTools/mafPositionFinder'
make: *** [Makefile:41: mafPositionFinder.all] Error 2
```